### PR TITLE
Fix iphone

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "singleQuote": false
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,22 @@
-import { useState } from "react";
-import useWeather from "./hooks/useWeather";
-import useWeatherMap from "./hooks/useWeatherMap";
-import Header from "./components/Header";
-import useAddress from "./hooks/useAddress";
-import Weather from "./components/Weather";
-import styled from "styled-components";
-import Footer from "./components/Footer";
-import StartScreen from "./components/StartScreen";
+import { useState } from 'react';
+import useWeather from './hooks/useWeather';
+import useWeatherMap from './hooks/useWeatherMap';
+import Header from './components/Header';
+import useAddress from './hooks/useAddress';
+import Weather from './components/Weather';
+import styled from 'styled-components';
+import Footer from './components/Footer';
+import StartScreen from './components/StartScreen';
 
 const StyledApp = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 100%;
   overflow: hidden;
 `;
 function App() {

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,12 @@
-import { useState } from 'react';
-import useWeather from './hooks/useWeather';
-import useWeatherMap from './hooks/useWeatherMap';
-import Header from './components/Header';
-import useAddress from './hooks/useAddress';
-import Weather from './components/Weather';
-import styled from 'styled-components';
-import Footer from './components/Footer';
-import StartScreen from './components/StartScreen';
+import { useState } from "react";
+import useWeather from "./hooks/useWeather";
+import useWeatherMap from "./hooks/useWeatherMap";
+import Header from "./components/Header";
+import useAddress from "./hooks/useAddress";
+import Weather from "./components/Weather";
+import styled from "styled-components";
+import Footer from "./components/Footer";
+import StartScreen from "./components/StartScreen";
 
 const StyledApp = styled.div`
   position: absolute;
@@ -17,7 +17,10 @@ const StyledApp = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  overflow: hidden;
+  /* On extremely small device, this will allow forecast to overflow causing vertical scroll,
+    which is more desirable than hiding it.
+  */
+  /* overflow: hidden; */
 `;
 function App() {
   // Keeping weather and weatherMap in the state because they're connected to the element on the page

--- a/src/components/Day.js
+++ b/src/components/Day.js
@@ -1,11 +1,11 @@
-import { useEffect, useState } from 'react';
-import styled from 'styled-components';
-import { getTemp } from '../utils';
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+import { getTemp } from "../utils";
 
 const StyledDay = styled.button`
   display: block;
   width: calc(100% / 6);
-  padding: 2rem 1rem 5rem;
+  padding: 2rem 1rem;
   font-size: var(--fz-sm);
   /* border: 2px solid red; */
   &.active,
@@ -51,7 +51,7 @@ const Day = (props) => {
 
   const [isActive, setIsActive] = useState(active);
 
-  const day = date.split(',')[0];
+  const day = date.split(",")[0];
   const convertedMin = getTemp(isMetric, min);
   const convertedMax = getTemp(isMetric, max);
 
@@ -65,7 +65,7 @@ const Day = (props) => {
   };
 
   return (
-    <StyledDay className={isActive ? 'active' : ''} onClick={handleDayClick}>
+    <StyledDay className={isActive ? "active" : ""} onClick={handleDayClick}>
       <span className="icon-container icon-small">
         <img
           src={`http://openweathermap.org/img/wn/${icon}@2x.png`}

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -2,11 +2,12 @@ import styled from "styled-components";
 
 const StyledFooter = styled("footer")`
   width: 100%;
+  /* height: var(--height-footer); */
   padding: 0.5em;
+  background: var(--clr-forecast);
   font-size: var(--fz-xs);
   text-align: center;
   color: rgba(0, 0, 0, 0.7);
-  height: var(--height-footer);
 
   @media (min-height: 570px) {
     padding: 1em;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,8 +1,6 @@
 import styled from "styled-components";
 
 const StyledFooter = styled("footer")`
-  position: absolute;
-  bottom: 0;
   width: 100%;
   padding: 0.5em;
   font-size: var(--fz-xs);

--- a/src/components/InfoDisplay.js
+++ b/src/components/InfoDisplay.js
@@ -6,7 +6,8 @@ import MoonBar from "./MoonBar";
 
 const StyledInfoDisplay = styled("div")`
   font-size: 1.6rem;
-  padding-bottom: var(--height-forecast);
+  /* removed forecast's fixed height  */
+  /* padding-bottom: var(--height-forecast); */
   width: 50vw;
   height: 100%;
   max-width: 250px;
@@ -61,7 +62,7 @@ const StyledInfoDisplay = styled("div")`
       align-items: center;
       flex-direction: column;
       width: min(max(40px, 5vw), 100%);
-      margin: 1rem;
+      margin: 2rem;
     }
   }
 `;
@@ -100,11 +101,11 @@ const InfoDisplay = (props) => {
       </div>
       <div className="flex sun-container">
         <div className="sun-item">
-          <Sunrise className="icon" width="100%" height="50%" />
+          <Sunrise className="icon" width="100%" />
           <span>{sunrise}</span>
         </div>
         <div className="sun-item">
-          <Sunset className="icon" width="100%" height="50%" />
+          <Sunset className="icon" width="100%" />
           <span>{sunset}</span>
         </div>
       </div>

--- a/src/components/LargeWeather.js
+++ b/src/components/LargeWeather.js
@@ -6,7 +6,6 @@ const StyledLargeWeather = styled.article`
   /* height: 50vh; */
   font-size: 1.3rem;
   padding: 2rem 0;
-  height: calc(100% - var(--height-forecast));
 
   .wrapper-large-weather {
     position: relative;

--- a/src/components/LargeWeather.js
+++ b/src/components/LargeWeather.js
@@ -2,8 +2,8 @@ import InfoDisplay from "./InfoDisplay";
 import styled from "styled-components";
 
 const StyledLargeWeather = styled.article`
-  /* min-height: 35rem; */
-  /* height: 50vh; */
+  /*  Take up all available height*/
+  flex-grow: 1;
   font-size: 1.3rem;
   padding: 2rem 0;
 

--- a/src/components/StartScreen.js
+++ b/src/components/StartScreen.js
@@ -3,11 +3,14 @@ import { ReactComponent as Seasons } from "../assets/seasons.svg";
 
 const StyledStartScreen = styled("div")`
   padding: 2rem;
-  height: calc(100% - var(--height-header));
   display: flex;
   flex-direction: column;
   justify-content: center;
   padding-bottom: var(--height-footer);
+
+  /* This will prevent Seasons from growing too big and pushing StartScreen it downward causing overflow */
+  /* This also ensures that children is contained within the flex item(StartScreen)  */
+  overflow: hidden;
 
   .copy {
     margin: 1em auto 2em;
@@ -16,8 +19,9 @@ const StyledStartScreen = styled("div")`
     opacity: 0.8;
   }
   svg {
+    /* Fill in all available space */
     width: 100%;
-    height: 60%;
+    height: 100%;
   }
 `;
 

--- a/src/components/Weather.js
+++ b/src/components/Weather.js
@@ -4,10 +4,14 @@ import LargeWeather from "./LargeWeather";
 import WeeklyForecast from "./WeeklyForecast";
 
 const StyledWeather = styled.main`
+  /* 
+  take up all available space from the container. 
+  The default behavior is to take content's height
+  */
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  /* height: calc(100% - var(--height-header)); */
 `;
 
 const Weather = ({ weatherDays, isMetric, mapUrl, loading, address }) => {

--- a/src/components/Weather.js
+++ b/src/components/Weather.js
@@ -7,7 +7,7 @@ const StyledWeather = styled.main`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: calc(100% - var(--height-header));
+  /* height: calc(100% - var(--height-header)); */
 `;
 
 const Weather = ({ weatherDays, isMetric, mapUrl, loading, address }) => {

--- a/src/components/WeeklyForecast.js
+++ b/src/components/WeeklyForecast.js
@@ -7,7 +7,7 @@ const StyledWeeklyForecast = styled("div")`
   left: 0; */
   width: 100%;
   /* height: var(--height-forecast); */
-  background: rgba(232, 232, 232, 0.5);
+  background: var(--clr-forecast);
   /* padding-bottom: 5rem; */
   .wrapper-weekly-forecast {
     display: flex;

--- a/src/components/WeeklyForecast.js
+++ b/src/components/WeeklyForecast.js
@@ -1,12 +1,12 @@
-import styled from 'styled-components';
-import Day from './Day';
+import styled from "styled-components";
+import Day from "./Day";
 
-const StyledWeeklyForecast = styled('div')`
-  position: absolute;
+const StyledWeeklyForecast = styled("div")`
+  /* position: absolute;
   bottom: 0;
-  left: 0;
+  left: 0; */
   width: 100%;
-  height: var(--height-forecast);
+  /* height: var(--height-forecast); */
   background: rgba(232, 232, 232, 0.5);
   /* padding-bottom: 5rem; */
   .wrapper-weekly-forecast {

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -27,7 +27,8 @@ export default createGlobalStyle`
     font-size: var(--fz-md);
     font-family: 'Roboto', sans-serif;
     height: 100vh;
-    height: -webkit-fill-available
+    height: -webkit-fill-available;
+    height: fill-available;
   } 
 
   button {

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -7,6 +7,7 @@ export default createGlobalStyle`
   :root {
     --clr-primary: orange;
     --clr-secondary: #635e9b;
+    --clr-forecast:rgba(232, 232, 232, 0.5);
     --height-forecast: 22vh;
     --height-footer: 3em;
     --height-header: 145px;


### PR DESCRIPTION
- Fixed layout issue specifically, but not limited to iPhone.
- Made App component absolute to body because App is NOT the direct children of body. (<div id="roo"> is sitting in between them)
- Removed all fixed height
- Allowed app children to overflow, which enables users on small phones to scroll down and select forecast.
- Tested on iPhone7 and Samsung Galaxy